### PR TITLE
Create BaseGenerator class to inherit from and fix remo error.

### DIFF
--- a/.lune/install.luau
+++ b/.lune/install.luau
@@ -12,9 +12,12 @@ local PROJECT_SYNC_TOOLS = { "rojo", "argon" }
 local EXC_OPTIONS: process.ExecOptions = { stdio = "forward" }
 
 for _, tool in PROJECT_SYNC_TOOLS do
-    local success = pcall(process.exec, tool, {"sourcemap", PROJECT_FILE, "--output", "sourcemap.json"}, EXC_OPTIONS)
-    if success then break end
+	local success = pcall(process.exec, tool, { "sourcemap", PROJECT_FILE, "--output", "sourcemap.json" }, EXC_OPTIONS)
+	if success then
+		break
+	end
 end
 
-process.exec("wally", {"install"}, EXC_OPTIONS)
-process.exec("wally-package-types", {"Packages", "--sourcemap", "sourcemap.json"}, EXC_OPTIONS)
+process.exec("wally", { "install" }, EXC_OPTIONS)
+process.exec("wally-package-types", { "Packages", "--sourcemap", "sourcemap.json", "Packages" }, EXC_OPTIONS)
+process.exec("wally-package-types", { "Packages", "--sourcemap", "sourcemap.json", "DevPackages" }, EXC_OPTIONS)

--- a/rokit.toml
+++ b/rokit.toml
@@ -13,5 +13,5 @@ argon = "argon-rbx/argon@2.0.27"
 
 # Wally Tools:
 wally = "UpliftGames/wally@0.3.2"
-wally-package-types = "JohnnyMorganz/wally-package-types@1.6.2"
+wally-package-types = "JohnnyMorganz/wally-package-types@1.4.2"
 selene = "Kampfkarren/selene@0.29.0"

--- a/src/Shared/maze/Generation/BaseGenerator.luau
+++ b/src/Shared/maze/Generation/BaseGenerator.luau
@@ -1,0 +1,11 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local types = require(ReplicatedStorage.maze.types)
+
+export type BaseGenerator<NodeMeta> = {
+	GetMaze: (self: BaseGenerator<NodeMeta>) -> { [number]: { [number]: types.Node<NodeMeta> } },
+	Generate: (self: BaseGenerator<NodeMeta>) -> (),
+	Build: (self: BaseGenerator<NodeMeta>) -> (),
+	IsComplete: (self: BaseGenerator<NodeMeta>) -> boolean,
+}
+
+return {}

--- a/src/Shared/maze/Generation/RecursiveBacktracker.luau
+++ b/src/Shared/maze/Generation/RecursiveBacktracker.luau
@@ -1,6 +1,7 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local MazeConfig = require(ReplicatedStorage.core.MazeConfig)
+local BaseGenerator = require(script.Parent.BaseGenerator)
 local types = require(script.Parent.Parent.types)
 
 local size = MazeConfig.mazeSize
@@ -10,14 +11,13 @@ type NodeMeta = {
 	visited: boolean,
 }
 
-type RecursiveBacktracker = {
-	GetMaze: (self: _RecursiveBacktracker) -> { [number]: { [number]: types.Node<NodeMeta> } },
-	Generate: (self: _RecursiveBacktracker) -> (),
-	Completed: boolean,
+type RecursiveBacktracker = BaseGenerator.BaseGenerator<NodeMeta> & {
+	Build: (self: _RecursiveBacktracker) -> (),
 }
 
 type _RecursiveBacktracker = RecursiveBacktracker & {
 	_Maze: { [number]: { [number]: types.Node<NodeMeta> } },
+	Completed: boolean,
 	GetNeighbors: (self: _RecursiveBacktracker, x: number, y: number) -> { types.Node<NodeMeta> },
 	SetDirection: (self: _RecursiveBacktracker, node1: types.Node<NodeMeta>, node2: types.Node<NodeMeta>) -> (),
 }
@@ -125,6 +125,16 @@ function RecursiveBacktracker.Generate(self: _RecursiveBacktracker)
 	end
 
 	self.Completed = true
+end
+
+function RecursiveBacktracker.BuildMaze(self: _RecursiveBacktracker)
+	if not self.Completed then
+		warn("Maze is not completed.")
+	end
+end
+
+function RecursiveBacktracker.IsComplete(self: _RecursiveBacktracker)
+	return self.Completed
 end
 
 return RecursiveBacktracker

--- a/tests/MazeGenerators/RecursiveBacktracker.spec.luau
+++ b/tests/MazeGenerators/RecursiveBacktracker.spec.luau
@@ -10,11 +10,11 @@ return function()
 
 			print("Generating maze...")
 
-			while not Maze.Completed do
+			while not Maze:IsComplete() do
 				task.wait()
 			end
 
-			expect(Maze.Completed).to.be.ok()]]
+			expect(Maze:IsComplete()).to.be.ok()]]
 			-- Find a better way to write this
 			expect(true == true).to.be.ok() -- placeholder for now
 		end)

--- a/tests/init.server.luau
+++ b/tests/init.server.luau
@@ -1,6 +1,9 @@
 --!nocheck
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
 local testez = require(ReplicatedStorage.DevPackages.testez)
 
-testez.TestBootstrap:run({ script.Parent }, testez.Reporters.TextReporter)
+if RunService:IsStudio() then
+	testez.TestBootstrap:run({ script.Parent }, testez.Reporters.TextReporterQuiet)
+end


### PR DESCRIPTION
### Base Generator class
. Maze generators inherit from this to organize types.

### Fixed remo issue
. Changed Wally-Package-Types from 1.6.2 to 1.4.2 fixed the issue.